### PR TITLE
(maint) add items from puppetlabs guidelines

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*  @puppetlabs/dumpling

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,70 @@
+# Community Guidelines and Code of Conduct
+
+We want to keep the Puppet communities awesome, and we need your help to keep it
+that way. While we have specific guidelines for various tools (see links below),
+in general, you should:
+
+* **Be nice**: Be courteous, respectful and polite to fellow community members. No
+  offensive comments related to gender, gender identity or expression, sexual
+  orientation, disability, physical appearance, body size, race, religion; no
+  sexual images in public spaces, real or implied violence, intimidation,
+  oppression, stalking, following, harassing photography or recording, sustained
+  disruption of talks or other events, inappropriate physical contact, doxxing, or
+  unwelcome sexual attention will be tolerated. We like nice people way better
+  than mean ones!
+* **Encourage diversity and participation**: Make everyone in our community feel
+  welcome, regardless of their background, and do everything possible to encourage
+  participation in our community.
+* **Focus on constructive criticisms**: When offering suggestions, whether in online
+  discussions or as comments on a pull request, you should always use welcoming
+  and inclusive language. Be respectful of differing viewpoints and the fact that
+  others may not have the same experiences you do. Offer suggestions for
+  improvement, rather than focusing on mistakes. When others critique your work or
+  ideas, gracefully accept the criticisms and default to assuming good intentions.
+* **Keep it legal**: Basically, don't get us in trouble. Share only content that you
+  own, do not share private or sensitive information, and don't break the law.
+* **Stay on topic**: Keep conversation in a thread on topic, whether that's a pull
+  request or a Slack conversation or anything else. Make sure that you are posting
+  to the correct channel and remember that nobody likes spam.
+
+## Guideline violations --- 3 strikes method
+
+The point of this section is not to find opportunities to punish people, but we
+do need a fair way to deal with people who do harm to our community. Extreme
+violations of a threatening, abusive, destructive, or illegal nature will be
+addressed immediately and are not subject to 3 strikes.
+
+* First occurrence: We'll give you a friendly, but public, reminder that the
+  behavior is inappropriate according to our guidelines.
+* Second occurrence: We'll send you a private message with a warning that any
+  additional violations will result in removal from the community.
+* Third occurrence: Depending on the violation, we might need to delete or ban
+  your account.
+
+Notes:
+
+* Obvious spammers are banned on first occurrence. If we don’t do this, we’ll
+  have spam all over the place.
+* Violations are forgiven after 6 months of good behavior, and we won’t hold a grudge.
+* People who are committing minor formatting / style infractions will get some
+  education, rather than hammering them in the 3 strikes process.
+
+Contact conduct@puppet.com to report abuse or appeal violations. This email list
+goes to Kara Sowles (kara at puppet.com) and Katie Abbott (katie dot abbott at
+puppet.com). In the case of appeals, we know that mistakes happen, and we’ll
+work with you to come up with a fair solution if there has been a
+misunderstanding.
+
+## Full text
+
+See our [full community guidelines](https://puppet.com/community/community-guidelines),
+covering Slack, IRC, events and other forms of community participation.
+
+## Credits
+
+Credit to [01.org](https://01.org/community/participation-guidelines) and
+[meego.com](http://wiki.meego.com/Community_guidelines), since they formed the
+starting point for many of these guidelines.
+
+The Event Code of Conduct is based on the [example policy from the Geek Feminism wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment),
+created by the Ada Initiative and other volunteers. The [PyCon Code of Conduct](https://github.com/python/pycon-code-of-conduct) also served as inspiration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,171 @@
 * Visit the dummy application at [http://localhost:4200](http://localhost:4200).
 
 For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
+
+# How to contribute
+
+Third-party patches are essential for keeping Puppet great. We simply can't
+access the huge number of platforms and myriad configurations for running
+Puppet. We want to keep it as easy as possible to contribute changes that
+get things working in your environment. There are a few guidelines that we
+need contributors to follow so that we can have a chance of keeping on
+top of things.
+
+## Puppet Core vs Modules
+
+New functionality is typically directed toward modules to provide a slimmer
+Puppet Core, reducing its surface area, and to allow greater freedom for
+module maintainers to ship releases at their own cadence, rather than
+being held to the cadence of Puppet releases. With Puppet 4's "all in one"
+packaging, a list of modules at specific versions will be packaged with the
+core so that popular types and providers will still be available as part of
+the "out of the box" experience.
+
+Generally, new types and new OS-specific providers for existing types should
+be added in modules. Exceptions would be things like new cross-OS providers
+and updates to existing core types.
+
+If you are unsure of whether your contribution should be implemented as a
+module or part of Puppet Core, you may visit [#puppet-dev on slack](https://puppetcommunity.slack.com/), or ask on
+the [puppet-dev mailing list](https://groups.google.com/forum/#!forum/puppet-dev) for advice.
+
+## Getting Started
+
+* Make sure you have a [Jira account](https://tickets.puppetlabs.com).
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* Submit a Jira ticket for your issue if one does not already exist.
+  * Clearly describe the issue including steps to reproduce when it is a bug.
+  * Make sure you fill in the earliest version that you know has the issue.
+  * A ticket is not necessary for [trivial changes](https://puppet.com/community/trivial-patch-exemption-policy)
+* Fork the repository on GitHub.
+
+## Making Changes
+
+* Create a topic branch from where you want to base your work.
+  * This is usually the master branch.
+  * Only target release branches if you are certain your fix must be on that
+    branch.
+  * To quickly create a topic branch based on master, run `git checkout -b
+    fix/master/my_contribution master`. Please avoid working directly on the
+    `master` branch.
+* Make commits of logical and atomic units.
+* Check for unnecessary whitespace with `git diff --check` before committing.
+* Make sure your commit messages are in the proper format. If the commit
+  addresses an issue filed in the
+  [Puppet Jira project](https://tickets.puppetlabs.com/browse/PUP), start
+  the first line of the commit with the issue number in parentheses.
+
+  ```
+      (PUP-1234) Make the example in CONTRIBUTING imperative and concrete
+
+      Without this patch applied the example commit message in the CONTRIBUTING
+      document is not a concrete example. This is a problem because the
+      contributor is left to imagine what the commit message should look like
+      based on a description rather than an example. This patch fixes the
+      problem by making the example concrete and imperative.
+
+      The first line is a real-life imperative statement with a ticket number
+      from our issue tracker. The body describes the behavior without the patch,
+      why this is a problem, and how the patch fixes the problem when applied.
+  ```
+* Make sure you have added the necessary tests for your changes.
+* For details on how to run tests, please see [the quickstart guide](https://github.com/puppetlabs/puppet/blob/master/docs/quickstart.md)
+
+## Writing Translatable Code
+
+We use [gettext tooling](https://github.com/puppetlabs/gettext-setup-gem) to
+extract user-facing strings and pull in translations based on the user's locale
+at runtime. In order for this tooling to work, all user-facing strings must be
+wrapped in the `_()` translation function, so they can be extracted into files
+for the translators.
+
+When adding user-facing strings to your work, follow these guidelines:
+
+* Use full sentences. Strings built up out of concatenated bits are hard to translate.
+* Use string formatting instead of interpolation. Use the hash format and give good names to the placeholder values that can be used by translators to understand the meaning of the formatted values.
+  For example: `_('Creating new user %{name}.') % { name: user.name }`
+* Use `n_()` for pluralization. (see gettext gem docs linked above for details)
+
+It is the responsibility of contributors and code reviewers to ensure that all
+user-facing strings are marked in new PRs before merging.
+
+## Making Trivial Changes
+
+For [changes of a trivial nature](https://puppet.com/community/trivial-patch-exemption-policy), it is not always necessary to create a new
+ticket in Jira. In this case, it is appropriate to start the first line of a
+commit with one of  `(docs)`, `(maint)`, or `(packaging)` instead of a ticket
+number.
+
+If a Jira ticket exists for the documentation commit, you can include it
+after the `(docs)` token.
+
+```
+    (docs)(DOCUMENT-000) Add docs commit example to CONTRIBUTING
+
+    There is no example for contributing a documentation commit
+    to the Puppet repository. This is a problem because the contributor
+    is left to assume how a commit of this nature may appear.
+
+    The first line is a real-life imperative statement with '(docs)' in
+    place of what would have been the PUP project ticket number in a
+    non-documentation related commit. The body describes the nature of
+    the new documentation or comments added.
+```
+
+For commits that address trivial repository maintenance tasks or packaging
+issues, start the first line of the commit with `(maint)` or `(packaging)`,
+respectively.
+
+## Submitting Changes
+
+* Sign the [Contributor License Agreement](http://cla.puppet.com/).
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a pull request to the repository in the puppetlabs organization.
+* Update your Jira ticket to mark that you have submitted code and are ready
+  for it to be reviewed (Status: Ready for Merge).
+  * Include a link to the pull request in the ticket.
+* The core team looks at Pull Requests on a regular basis in a weekly triage
+  meeting that we hold in a public Google Hangout. The hangout is announced in
+  the weekly status updates that are sent to the puppet-dev list. Notes are
+  posted to the [Puppet Community community-triage
+  repo](https://github.com/puppet-community/community-triage/tree/master/core/notes)
+  and include a link to a YouTube recording of the hangout.
+* After feedback has been given we expect responses within two weeks. After two
+  weeks we may close the pull request if it isn't showing any activity.
+
+## Revert Policy
+
+By running tests in advance and by engaging with peer review for prospective
+changes, your contributions have a high probability of becoming long lived
+parts of the the project. After being merged, the code will run through a
+series of testing pipelines on a large number of operating system
+environments. These pipelines can reveal incompatibilities that are difficult
+to detect in advance.
+
+If the code change results in a test failure, we will make our best effort to
+correct the error. If a fix cannot be determined and committed within 24 hours
+of its discovery, the commit(s) responsible _may_ be reverted, at the
+discretion of the committer and Puppet maintainers. This action would be taken
+to help maintain passing states in our testing pipelines.
+
+The original contributor will be notified of the revert in the Jira ticket
+associated with the change. A reference to the test(s) and operating system(s)
+that failed as a result of the code change will also be added to the Jira
+ticket. This test(s) should be used to check future submissions of the code to
+ensure the issue has been resolved.
+
+### Summary
+
+* Changes resulting in test pipeline failures will be reverted if they cannot
+  be resolved within one business day.
+
+## Additional Resources
+
+* [Puppet community guidelines](https://puppet.com/community/community-guidelines)
+* [Bug tracker (Jira)](https://tickets.puppetlabs.com)
+* [Contributor License Agreement](http://cla.puppet.com/)
+* [General GitHub documentation](https://help.github.com/)
+* [GitHub pull request documentation](https://help.github.com/articles/creating-a-pull-request/)
+* #puppet-dev IRC channel on freenode.org ([Archive](https://botbot.me/freenode/puppet-dev/))
+* [puppet-dev mailing list](https://groups.google.com/forum/#!forum/puppet-dev)
+* [Community PR Triage notes](https://github.com/puppet-community/community-triage/tree/master/core/notes)


### PR DESCRIPTION
This commit will add documentation outlined in Puppet repo guidelines