### PR TITLE
(maint) remove selected attribute

### DIFF
--- a/addon/components/ivy-tabs-tab.hbs
+++ b/addon/components/ivy-tabs-tab.hbs
@@ -6,7 +6,6 @@
   aria-selected="{{this.isSelected}}"
   role="tab"
   href="{{this.href}}"
-  selected="{{this.isSelected}}"
   {{on "click" this.handleClick}}
   ...attributes>
   {{~yield~}}

--- a/addon/components/ivy-tabs-tab.js
+++ b/addon/components/ivy-tabs-tab.js
@@ -131,21 +131,6 @@ export default class IvyTabsTabComponent extends Component {
   }
 
   /**
-   * The `selected` attribute of the tab element. If the tab's `isSelected`
-   * property is `true` this will be the literal string 'selected', otherwise
-   * it will be `undefined`.
-   *
-   * @property selected
-   * @type String
-   */
-  get selected() {
-    if (this.isSelected) {
-      return 'selected';
-    }
-    return undefined;
-  }
-
-  /**
    * The `ivy-tabs-tabpanel` associated with this tab.
    *
    * @property tabPanel


### PR DESCRIPTION
`selected` is only an attribute that should be applied to options, so this removes the calculation of selected, and the attribute being applied to the `a` tag.