### PR TITLE
(maint) avoid calling "onSelect" when the tab is already selected

### DIFF
--- a/addon/components/ivy-tabs-tab.js
+++ b/addon/components/ivy-tabs-tab.js
@@ -105,6 +105,7 @@ export default class IvyTabsTabComponent extends Component {
   select() {
     const onSelect = this.args.onSelect;
     if (
+      !this.isSelected &&
       !this.isDestroying &&
       !this.isDestroyed &&
       typeof onSelect === 'function'

--- a/tests/dummy/app/controllers/dynamic-tabs.js
+++ b/tests/dummy/app/controllers/dynamic-tabs.js
@@ -28,9 +28,7 @@ export default class DynamicTabsController extends Controller {
 
   @action
   updateDynamicSelection(item) {
-    if (this.selection !== item) {
-      this.selection = item;
-    }
+    this.selection = item;
   }
 
   get checkedItems() {

--- a/tests/dummy/app/controllers/query-params.js
+++ b/tests/dummy/app/controllers/query-params.js
@@ -11,8 +11,6 @@ export default class QueryParamsController extends Controller {
 
   @action
   updateQuerySelection(newValue) {
-    if (this.selection !== newValue) {
-      this.selection = newValue;
-    }
+    this.selection = newValue;
   }
 }


### PR DESCRIPTION
If the tab is already selected, there is no reason to call "onSelect" This changes the logic for the callback to avoid calling if the tab is selected. The tests were updated to agree with that expected behavior.