### PR TITLE
(maint) Limit scope and timing of selection

### DIFF
--- a/addon/components/ivy-tabs-tab.js
+++ b/addon/components/ivy-tabs-tab.js
@@ -56,7 +56,9 @@ export default class IvyTabsTabComponent extends Component {
   @action
   handleClick(event) {
     event.preventDefault();
-    this.select();
+    if (this.args.tabList.isRegistered(this)) {
+      this.select();
+    }
   }
 
   get href() {
@@ -116,7 +118,7 @@ export default class IvyTabsTabComponent extends Component {
 
   @action
   focus() {
-    let element = document.getElementById(this.id);
+    const element = document.getElementById(this.id);
     if (element) {
       element.focus();
     }


### PR DESCRIPTION
Selection is done by the caller as a part of the callbacks registered
via the tab component and tabs. The timing of this callback depeends
on when the tabs are rendered. This applies a bottleneck to ensure
that the tab selection is honored when specified, by delaying selection
until after the render loop for the current tabs are rendered.
